### PR TITLE
feat: Implement OriginalErr method

### DIFF
--- a/error.go
+++ b/error.go
@@ -77,3 +77,17 @@ func FromCause(cause error) WrapOpt {
 		w.causer = &causer{cause: cause}
 	}
 }
+
+// OriginalErr returns the original error without any wrapping
+func OriginalErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var we *wrapped
+	if !errors.As(err, &we) {
+		return err
+	}
+
+	return we.error
+}


### PR DESCRIPTION
## 작업 배경
1. wrapped는 Unwrap메서드를 직접 구현하지 않아, errors.Unwrap시에 포인터로 임베딩된 causer가 nil이라면 Unwrap을 인식하지 못하는 현상이 있습니다.
2. 이를 해결하기 위해 근본적인 에러의 원인을 추적할 수 있는 메서드를 구현합니다.

## 사용 예시
`rootErr := errorutil.OriginalErr(err)`